### PR TITLE
github: handle multiline commit messages

### DIFF
--- a/github_cli.go
+++ b/github_cli.go
@@ -97,8 +97,9 @@ func followRepoEvents(irc *goirc.Connection, cli *github.Client, owner, repo, ir
 						continue
 					}
 					time.Sleep(time.Second)
+					msg := strings.Replace(strings.Replace(*c.Message, "\n", " ", -1), "\r", " ", -1)
 					irc.Privmsgf(irchan, "\x032[%s/%s]\x03 %s - %s \x038https://github.com/%s/%s/commit/%s\x03",
-						owner, repo, *c.Author.Name, *c.Message, owner, repo, *c.SHA)
+						owner, repo, *c.Author.Name, msg, owner, repo, *c.SHA)
 				}
 			}
 		}


### PR DESCRIPTION
as @hwine noticed multiline commit messages get truncated in irc due
to the \r or \n being included in the r2d2 message and prematurely
terminating the IRC message.

We replace them with spaces to fix this.

NB: I haven't tested this. Alternatively we could just include the first line.