### PR TITLE
github: only write first line of multiline commit messages

### DIFF
--- a/github_cli.go
+++ b/github_cli.go
@@ -97,9 +97,9 @@ func followRepoEvents(irc *goirc.Connection, cli *github.Client, owner, repo, ir
 						continue
 					}
 					time.Sleep(time.Second)
-					msg := strings.Replace(strings.Replace(*c.Message, "\n", " ", -1), "\r", " ", -1)
+					msgFirstLine := strings.Replace(strings.SplitN(*c.Message, "\n", 2)[0], "\r", "", -1)
 					irc.Privmsgf(irchan, "\x032[%s/%s]\x03 %s - %s \x038https://github.com/%s/%s/commit/%s\x03",
-						owner, repo, *c.Author.Name, msg, owner, repo, *c.SHA)
+						owner, repo, *c.Author.Name, msgFirstLine, owner, repo, *c.SHA)
 				}
 			}
 		}


### PR DESCRIPTION
refs: https://github.com/jvehent/r2d2/pull/11#commitcomment-28241162

Only include the first line of multi-line commit messages since users can click the link to get the full message.